### PR TITLE
feat(ui): add separator and improve UI feedback in notes and chat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-label": "^2.1.7",
+        "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "ai": "^5.0.0-alpha.12",
         "class-variance-authority": "^0.7.1",
@@ -2463,6 +2464,29 @@
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "ai": "^5.0.0-alpha.12",
     "class-variance-authority": "^0.7.1",

--- a/src/app/(main)/navbar.tsx
+++ b/src/app/(main)/navbar.tsx
@@ -19,7 +19,7 @@ export function Navbar() {
             height={32}
             className="rounded"
           />
-          Smart Notes
+          Smart Notitas
         </Link>
         <div className="flex items-center gap-2">
           <ModeToggle />

--- a/src/app/(main)/notes/ai-chat-button.tsx
+++ b/src/app/(main)/notes/ai-chat-button.tsx
@@ -199,6 +199,9 @@ function ChatMessage({ message }: ChatMessageProps) {
         {currentStep?.type === "text" && (
           <Markdown>{currentStep.text}</Markdown>
         )}
+        {currentStep?.type === "tool-invocation" && (
+          <div className="italic animate-pulse">Buscando en tus notas...</div>
+        )}
       </div>
     </div>
   );

--- a/src/app/(main)/notes/note-preview-dialog.tsx
+++ b/src/app/(main)/notes/note-preview-dialog.tsx
@@ -15,6 +15,7 @@ import { api } from "../../../../convex/_generated/api";
 import { useMutation } from "convex/react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { Separator } from "@/components/ui/separator";
 
 interface NotePreviewDialogProps {
   note: Doc<"notes">;
@@ -52,7 +53,8 @@ export function NotePreviewDialog({ note }: NotePreviewDialogProps) {
           <DialogTitle>{note.title}</DialogTitle>
         </DialogHeader>
         <div className="mt-4 whitespace-pre-wrap">{note.body}</div>
-        <DialogFooter className="mt-6">
+        <Separator />
+        <DialogFooter className="mt-2">
           <Button
             variant="destructive"
             className="gap-2"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,13 @@
 import logo from "@/assets/logo.png";
 import { Button } from "@/components/ui/button";
+import { convexAuthNextjsToken } from "@convex-dev/auth/nextjs/server";
 import Image from "next/image";
 import Link from "next/link";
 
-export default function Home() {
+export default async function Home() {
+  const token = await convexAuthNextjsToken();
+  const isAuthenticated = !!token;
+
   return (
     <div className="min-h-screen flex flex-col items-center justify-center px-4 py-16">
       <main className="max-w-4xl mx-auto text-center space-y-8">
@@ -21,41 +25,22 @@ export default function Home() {
 
         {/* Title */}
         <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight">
-          Smart Notes
+          Smart Notitas
         </h1>
 
         {/* Description */}
         <p className="text-lg sm:text-xl text-muted-foreground max-w-2xl mx-auto leading-relaxed">
-          A simple note-taking app with AI chatbot integration. Ask the chatbot
-          anything about your notes to retrieve and summarize that information.
+          Una aplicación de toma de notas con integración de chatbot de IA
+          construida con Convex y el SDK de Vercel AI.
         </p>
 
         {/* CTA Button */}
         <div className="pt-4">
           <Button asChild size="lg" className="text-lg px-8 py-3">
-            <Link href="/notes">Get Started</Link>
+            <Link href="/notes">{isAuthenticated ? "Seguir" : "Empezar"}</Link>
           </Button>
         </div>
-
-        {/* Built with section */}
-        <div className="pt-8 text-sm text-muted-foreground">
-          <p>Built with Convex and the Vercel AI SDK</p>
-        </div>
       </main>
-
-      {/* Footer */}
-      <footer className="mt-auto pt-16 pb-8">
-        <div className="text-center">
-          <a
-            href="https://www.youtube.com/c/codinginflow"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
-            Full tutorial on YouTube →
-          </a>
-        </div>
-      </footer>
     </div>
   );
 }

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }


### PR DESCRIPTION
Add a Separator component between note preview content and footer to improve
visual separation. Show a pulsing italic message "Buscando en tus notas..."
during AI tool invocation to enhance user feedback in the chat interface.

Update branding text from "Smart Notes" to "Smart Notitas" for a friendlier,
localized feel. Modify the home page to detect authentication status and
adjust the call-to-action button text accordingly, improving user guidance.

Remove the footer with external links from the home page to simplify the UI.

Add @radix-ui/react-separator dependency and implement a reusable separator
component for consistent UI styling across the app.