### PR TITLE
fix: remove unused useMutation import in create-note-button.tsx

### DIFF
--- a/src/app/(main)/notes/create-note-button.tsx
+++ b/src/app/(main)/notes/create-note-button.tsx
@@ -20,7 +20,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useAction, useMutation } from "convex/react";
+import { useAction } from "convex/react";
 import { Plus } from "lucide-react";
 import { useState } from "react";
 import { useForm } from "react-hook-form";


### PR DESCRIPTION
Eliminate the unused useMutation import from convex/react to clean up
the code and avoid potential confusion. This change improves code
readability and maintainability in the create-note-button component.